### PR TITLE
Shorten long command text

### DIFF
--- a/components.go
+++ b/components.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"unicode"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -10,6 +12,7 @@ type ComponentWidget[T Command | Section] interface {
 	focus(bool)
 	getData() T
 	getHeight() int
+	setWidth(int)
 }
 
 type BaseWidget struct {
@@ -26,9 +29,14 @@ func (w *BaseWidget) getHeight() int {
 	return w.height
 }
 
+func (w *BaseWidget) setWidth(width int) {
+}
+
 type CommandWidget struct {
 	*BaseWidget
-	data Command
+	data        Command
+	description *tview.TextView
+	example     *tview.TextView
 }
 
 type SectionWidget struct {
@@ -38,6 +46,29 @@ type SectionWidget struct {
 
 func (w *CommandWidget) getData() Command {
 	return w.data
+}
+
+func shortenText(str string, max int) string {
+	lastSpaceIx := -1
+	len := 0
+	for i, r := range str {
+		if unicode.IsSpace(r) {
+			lastSpaceIx = i
+		}
+		len++
+		if len >= max {
+			if lastSpaceIx != -1 {
+				return str[:lastSpaceIx] + "..."
+			}
+			return str[:max]
+		}
+	}
+	return str
+}
+
+func (w *CommandWidget) setWidth(width int) {
+	w.description.SetText("[yellow]" + shortenText(w.data.Description, width))
+	w.example.SetText(shortenText(w.data.Example, width))
 }
 
 func (c Command) widget() *CommandWidget {
@@ -75,6 +106,8 @@ func (c Command) widget() *CommandWidget {
 			flex.GetItemCount() + 1,
 		},
 		c,
+		descText,
+		examText,
 	}
 }
 

--- a/pager.go
+++ b/pager.go
@@ -24,7 +24,7 @@ type Pager[T Section | Command] struct {
 	focus     int
 	page      int
 	pageStart []int
-	widgets   []*ComponentWidget[T]
+	widgets   []ComponentWidget[T]
 }
 
 func (r *Pager[T]) handleCommand(cmd string) {
@@ -76,10 +76,10 @@ func (r *Pager[T]) handleCommand(cmd string) {
 	case "view":
 		switch r.name {
 		case PAGER_SECTION:
-			s := any(r.widgets[r.focus].data).(Section)
+			s := any(r.widgets[r.focus].getData()).(Section)
 			r.ui.switchToCommandPager(s)
 		case PAGER_COMMAND:
-			c := any(r.widgets[r.focus].data).(Command)
+			c := any(r.widgets[r.focus].getData()).(Command)
 			r.ui.viewTldr(c)
 		}
 	case "back":
@@ -146,11 +146,11 @@ func (r *Pager[T]) update() {
 
 	var (
 		i int
-		w *ComponentWidget[T]
+		w ComponentWidget[T]
 	)
 
 	for i, w = range r.widgets[r.start:] {
-		height -= w.height
+		height -= w.getHeight()
 
 		if height < 1 ||
 			(r.ui.maxPerColumn > 0 && column.GetItemCount() == r.ui.maxPerColumn) {
@@ -164,7 +164,7 @@ func (r *Pager[T]) update() {
 			r.columns.AddItem(column, 0, 1, false)
 		}
 
-		column.AddItem(w, w.height, 1, false)
+		column.AddItem(w, w.getHeight(), 1, false)
 	}
 
 	r.end = r.start + i
@@ -199,7 +199,7 @@ func newSectionPager(ui *UI) *Pager[Section] {
 		name:    PAGER_SECTION,
 		ui:      ui,
 		columns: cols,
-		widgets: make([]*ComponentWidget[Section], len(ui.dataset.sections)),
+		widgets: make([]ComponentWidget[Section], len(ui.dataset.sections)),
 	}
 
 	i := 0
@@ -219,7 +219,7 @@ func newCommandPager(ui *UI, s Section) *Pager[Command] {
 		name:    PAGER_COMMAND,
 		ui:      ui,
 		columns: cols,
-		widgets: make([]*ComponentWidget[Command], len(s.Commands)),
+		widgets: make([]ComponentWidget[Command], len(s.Commands)),
 	}
 
 	for i, d := range s.Commands {

--- a/pager.go
+++ b/pager.go
@@ -188,6 +188,10 @@ func (r *Pager[T]) init() {
 	r.SetDrawFunc(func(_ tcell.Screen, _, _, _, _ int) (int, int, int, int) {
 		x, y, w, h := r.GetInnerRect()
 		r.draw(w, h)
+		colWidth := r.width / r.columnsN
+		for _, w := range r.widgets {
+			w.setWidth(colWidth)
+		}
 		return x, y, w, h
 	})
 }


### PR DESCRIPTION
Uses ellipsis.

Could use multi-line text, but ideally text will be rewritten to be more succinct.

Fixes #19